### PR TITLE
Fix entry align

### DIFF
--- a/simplecv.sty
+++ b/simplecv.sty
@@ -125,7 +125,7 @@
     \vspace{-\smallskipamount} \item[]\small{\textit{#4}}}
 
 \newcommand{\entrybig}[5][]{\item[#1]
-    \begin{tabular*}{0.97\textwidth}{l@{\extracolsep{\fill}}r}
+    \begin{tabular*}{0.98\textwidth}{l@{\extracolsep{\fill}}r}
     #2 & #3 \\ {\small#4} & {\small #5} \\ \end{tabular*}}
 
 % Fill year

--- a/simplecv.sty
+++ b/simplecv.sty
@@ -121,7 +121,7 @@
 \newcommand{\entrylabeled}[2][]{\item[#1]\small{#2}}
 
 \newcommand{\entrymid}[4][]{
-    \item[#1] \small{#2} \hfill \small{#3}
+    \item[#1] \small{#2} \hfill \small{#3}%
     \vspace{-\smallskipamount} \item[]\small{\textit{#4}}}
 
 \newcommand{\entrybig}[5][]{\item[#1]


### PR DESCRIPTION
Hi, I found that `\entry`, `\entrymid`, `\entrybig` cannot align:

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/68191508/189478185-014e82f8-74c9-4c67-9436-9c1282027fe1.png">

Test Code:

```LaTeX
\section{Education}

\outerlist{

\entrybig
{\textbf{ETH Zurich}}{Zurich, CH}
{M.S. in Computer Science, GPA: 5.63/6.00}{2018\textendash 2020}

\entrymid{1}{2020}{3}
\entry{1 \hfill 2020}
}
```

So I make some changes according to [stackexchange](https://tex.stackexchange.com/questions/422444/hfill-alignment-doesn%C2%B4t-work)

And the result is as following:

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/68191508/189478245-482947d8-19a9-44dd-bfa0-5ceaa4cf9abb.png">

I compiled by `latexmk` on MacOS, the arguments are:
```
"-synctex=1",
"-interaction=nonstopmode",
"-file-line-error",
"-bibtex", 
"-pdf",
"-emulate-aux-dir",
"--auxdir=.aux",
"-outdir=output",
"%DOC%"
```
