### PR TITLE
Fix entry align

### DIFF
--- a/simplecv.sty
+++ b/simplecv.sty
@@ -125,7 +125,7 @@
     \vspace{-\smallskipamount} \item[]\small{\textit{#4}}}
 
 \newcommand{\entrybig}[5][]{\item[#1]
-    \begin{tabular*}{0.97\textwidth}{l@{\extracolsep{\fill}}r}
+    \begin{tabular*}{0.98\textwidth}{l@{\extracolsep{\fill}}r}
     #2 & #3 \\ {\small#4} & {\small #5} \\ \end{tabular*}}
 
 % Fill year

--- a/simplecv.sty
+++ b/simplecv.sty
@@ -121,7 +121,7 @@
 \newcommand{\entrylabeled}[2][]{\item[#1]\small{#2}}
 
 \newcommand{\entrymid}[4][]{
-    \item[#1] \small{#2} \hfill \small{#3}
+    \item[#1] \small{#2} \hfill \small{#3}%
     \vspace{-\smallskipamount} \item[]\small{\textit{#4}}}
 
 \newcommand{\entrybig}[5][]{\item[#1]

--- a/simplecv.sty
+++ b/simplecv.sty
@@ -125,7 +125,7 @@
     \vspace{-\smallskipamount} \item[]\small{\textit{#4}}}
 
 \newcommand{\entrybig}[5][]{\item[#1]
-    \begin{tabular*}{0.98\textwidth}{l@{\extracolsep{\fill}}r}
+    \begin{tabular*}{\linewidth}{l@{\extracolsep{\fill}}r}
     #2 & #3 \\ {\small#4} & {\small #5} \\ \end{tabular*}}
 
 % Fill year


### PR DESCRIPTION
Based on [#2](https://github.com/dcetin/Simple-CV/pull/2), added an additional change to fix vertical spacing changes in `\entrybig`